### PR TITLE
fix: fix the newsfeed-error

### DIFF
--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -11,13 +11,16 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
     pagination_class = EndlessPagination
 
+    def get_queryset(self):
+        # This queryset will not be used, because you're overriding the `list` method,
+        # but it needs to be defined to prevent an AssertionError.
+        return NewsFeed.objects.none()
+
     def list(self, request):
         cached_newsfeeds = NewsFeedServices.get_cached_newsfeeds(request.user.id)
         page = self.paginator.paginate_cached_list(cached_newsfeeds, request)
         if page is None:
             queryset = NewsFeed.objects.filter(user=request.user)
             page = self.paginate_queryset(queryset)
-        serializer = NewsFeedSerializer(
-            page, context={"request": request}, many=True
-        )
+        serializer = NewsFeedSerializer(page, context={"request": request}, many=True)
         return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
fix the error
```
AssertionError at /api/newsfeeds/
'NewsFeedViewSet' should either include a `queryset` attribute, or override the `get_queryset()` method.
Request Method:	GET
Request URL:	http://localhost:8000/api/newsfeeds/
Django Version:	3.1.3
Exception Type:	AssertionError
Exception Value:	
'NewsFeedViewSet' should either include a `queryset` attribute, or override the `get_queryset()` method.
Exception Location:	/usr/local/lib/python3.6/dist-packages/rest_framework/generics.py, line 66, in get_queryset
Python Executable:	/usr/bin/python3
Python Version:	3.6.9
Python Path:	
['/vagrant',
 '/usr/lib/python36.zip',
 '/usr/lib/python3.6',
 '/usr/lib/python3.6/lib-dynload',
 '/usr/local/lib/python3.6/dist-packages',
 '/usr/lib/python3/dist-packages']
Server time:	Thu, 15 Jun 2023 09:54:01 +0000
```