### PR TITLE
feat: add the feature to let the comment and likes to get the data fr…

### DIFF
--- a/comments/listeners.py
+++ b/comments/listeners.py
@@ -1,4 +1,5 @@
 from utils.listeners import invalidate_object_cache
+from utils.redis_helper import RedisHelper
 
 
 def increase_comments_count(sender, instance, created, **kwargs):
@@ -13,7 +14,7 @@ def increase_comments_count(sender, instance, created, **kwargs):
     Tweet.objects.filter(id=instance.tweet_id).update(
         comments_count=F("comments_count") + 1
     )
-    invalidate_object_cache(Tweet, instance.tweet)
+    RedisHelper.increase_count(instance.tweet, "comments_count")
 
 
 def decrease_comments_count(sender, instance, **kwargs):
@@ -24,4 +25,4 @@ def decrease_comments_count(sender, instance, **kwargs):
     Tweet.objects.filter(id=instance.tweet_id).update(
         comments_count=F("comments_count") - 1
     )
-    invalidate_object_cache(Tweet, instance.tweet)
+    RedisHelper.decrease_count(instance.tweet, "comments_count")

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -23,9 +23,7 @@ class FriendshipApiTests(TestCase):
 
         # create followings and followers for dongxie
         for i in range(2):
-            follower = self.create_user(
-                f"dongxie_follower{i}", email="test1@gmail.com"
-            )
+            follower = self.create_user(f"dongxie_follower{i}", email="test1@gmail.com")
             Friendship.objects.create(from_user=follower, to_user=self.dongxie)
         for i in range(3):
             following = self.create_user(

--- a/likes/listeners.py
+++ b/likes/listeners.py
@@ -1,3 +1,6 @@
+from utils.redis_helper import RedisHelper
+
+
 def increase_likes_count(sender, instance, created, **kwargs):
     from django.db.models import F
 
@@ -19,6 +22,7 @@ def increase_likes_count(sender, instance, created, **kwargs):
     # method 1
     tweet = instance.content_object
     Tweet.objects.filter(id=instance.object_id).update(likes_count=F("likes_count") + 1)
+    RedisHelper.increase_count(instance.content_object, "likes_count")
 
     # method 2
     # tweet = instance.content_object
@@ -37,3 +41,4 @@ def decrease_likes_count(sender, instance, **kwargs):
 
     tweet = instance.content_object
     Tweet.objects.filter(id=instance.object_id).update(likes_count=F("likes_count") - 1)
+    RedisHelper.decrease_count(instance.content_object, "likes_count")

--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -28,9 +28,7 @@ class NewsFeedApiTests(TestCase):
             follower = self.create_user(f"user2_follower{i}", "user2@gmail.com")
             Friendship.objects.create(from_user=follower, to_user=self.user2)
         for i in range(3):
-            following = self.create_user(
-                f"user2_following{i}", "user2@gmail.com"
-            )
+            following = self.create_user(f"user2_following{i}", "user2@gmail.com")
             Friendship.objects.create(from_user=self.user2, to_user=following)
 
     def test_list(self):

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -8,6 +8,7 @@ from likes.services import LikeService
 from tweets.constants import TWEET_PHOTOS_UPLOAD_LIMIT
 from tweets.models import Tweet
 from tweets.services import TweetService
+from utils.redis_helper import RedisHelper
 
 
 class TweetSerializer(serializers.ModelSerializer):
@@ -31,10 +32,14 @@ class TweetSerializer(serializers.ModelSerializer):
         )
 
     def get_likes_count(self, obj):
-        return obj.like_set.count()
+        # select count(*)  -> redis get
+        # N+ 1 Query
+        # N 如果是 db query 是不可以接受的
+        # 但是如果是 redis query, 就可以接受
+        return RedisHelper.get_count(obj, "likes_count")
 
     def get_comments_count(self, obj):
-        return obj.comment_set.count()
+        return RedisHelper.get_count(obj, "comments_count")
 
     def get_has_liked(self, obj):
         return LikeService.has_liked(self.context["request"].user, obj)


### PR DESCRIPTION
The previous branch changed the denormalisation part, but the cache part needs to be changed as well
- like and comment count are both fetched from redis 
	- Note: If a data changes frequently, it is not suitable to be put in the cache, not with the tweet, but +1, -1 is possible, such as de, in, such functions, you need to put the like comment count in a separate place
- add the cache with likes/comments test  